### PR TITLE
Allow a default value for ENV variables used in configuration

### DIFF
--- a/src/Configuration/Alternatively.php
+++ b/src/Configuration/Alternatively.php
@@ -64,9 +64,10 @@ class Alternatively
         }
 
         $matches = [];
-        $found   = preg_match('/ENV\[(.*)\]/', $originalValue, $matches);
+        $found   = preg_match('/ENV\[([^|]+?)(\|(.+))?\]/u', $originalValue, $matches);
         if ($found === 1) {
-            $value = getenv($matches[1]);
+            $default = isset($matches[3]) ? $matches[3] : false;
+            $value   = getenv($matches[1]) ? : $default;
             if ($value === false) {
                 throw new SettingNotFoundException(sprintf("Environment variable '%s' was not found", $matches[1]));
             }
@@ -75,4 +76,3 @@ class Alternatively
         return $originalValue;
     }
 }
-

--- a/tests/unit/Configuration/SettingsTest.php
+++ b/tests/unit/Configuration/SettingsTest.php
@@ -93,6 +93,27 @@ class SettingsTest extends \PHPUnit_Framework_TestCase
     /**
      * @test
      */
+    public function testGet_SettingExistsAsEnvironmentVariable_ShouldNotReturnDefaultValueFromEnvironmentVariable()
+    {
+        $settings = new Settings(['key' => 'ENV[spinpans|james]']);
+        putenv('spinpans=joe');
+        $this->assertEquals('joe', $settings->get('key')->orFail());
+    }
+
+    /**
+     * @test
+     */
+    public function testGet_SettingDoesNotExistAsEnvironmentVariable_ShouldReturnDefaultValueFromEnvironmentVariable()
+    {
+        $settings = new Settings(['key' => 'ENV[spinpans|james]']);
+        // unset environment variable
+        putenv('spinpans');
+        $this->assertEquals('james', $settings->get('key')->orFail());
+    }
+
+    /**
+     * @test
+     */
     public function testGet_SettingIsArrayAndValueExistsAsEnvironmentVariable_ShouldReturnValueFromEnvironmentVariable()
     {
         $settings = new Settings(['key' => ['name' => 'ENV[spinpans]']]);


### PR DESCRIPTION
This PR will enable the use of a default value in case the environment variable is not set.

```json
  "remapHosts": {
      "mydomain.com" : "ENV[ATHENA_ENV_WEBSERVER_IP|172.17.0.1]"
    },
```