### PR TITLE
Fix missing body on http report

### DIFF
--- a/src/Event/Adapter/GuzzleReportMiddleware.php
+++ b/src/Event/Adapter/GuzzleReportMiddleware.php
@@ -37,7 +37,8 @@ class GuzzleReportMiddleware
         $method  = $message->getMethod();
         $uri     = $message->getUri();
         $headers = static::formatHeaders($message->getHeaders());
-        $body    = $message->getBody()->getContents();
+        $body    = strval($message->getBody());
+        
         $message->getBody()->rewind();
 
         return <<<EOF


### PR DESCRIPTION
@pproenca: With @yael-lorenzo-olx we noticed that since the last update (guzzle 6) the body of http requests is not being displayed on reports. I found out this issue: https://github.com/8p/GuzzleBundle/issues/48

I'm just casting the body to string, which properly handles the internal cursor on body stream. Another option would be to call the rewind method BEFORE getContents, but that feels to VHS for me.