### PR TITLE
Configuration option to turn on and off the screenshot in BDD

### DIFF
--- a/src/Event/Subscriber/BddSubscriber.php
+++ b/src/Event/Subscriber/BddSubscriber.php
@@ -203,17 +203,17 @@ class BddSubscriber implements EventSubscriberInterface
             }
         }
 
-        if (($resultCode == TestResult::FAILED) AND (Athena::settings()->get('bddScreenshotOnlyOnFailed')->orDefaultTo(true) == 'on')){
+        if (($resultCode == TestResult::FAILED) AND (Athena::settings()->get('bddScreenshotOnlyOnFailed')->orDefaultTo(true) == true)){
             $imageFileName = $this->takeScreenshot();
             $httpTransactions = $this->getHttpTransactionEvents();
 
             $this->report->finishStep($stepText, $valuesTables, $resultCode, $imageFileName, $exceptionMessage, $exceptionTrace, $exceptionType, $httpTransactions);
-        } elseif (Athena::settings()->get('bddScreenshotOnlyOnFailed')->orDefaultTo(true) == 'off') {
+        } elseif (Athena::settings()->get('bddScreenshotOnlyOnFailed')->orDefaultTo(true) == false) {
             $imageFileName = $this->takeScreenshot();
             $httpTransactions = $this->getHttpTransactionEvents();
 
             $this->report->finishStep($stepText, $valuesTables, $resultCode, $imageFileName, $exceptionMessage, $exceptionTrace, $exceptionType, $httpTransactions);
-        } elseif (($resultCode == TestResult::PASSED) AND (Athena::settings()->get('bddScreenshotOnlyOnFailed')->orDefaultTo(true) == 'on')) {
+        } elseif (($resultCode == TestResult::PASSED) AND (Athena::settings()->get('bddScreenshotOnlyOnFailed')->orDefaultTo(true) == true)) {
             $imageFileName = null;
             $httpTransactions = null;
 

--- a/src/Event/Subscriber/BddSubscriber.php
+++ b/src/Event/Subscriber/BddSubscriber.php
@@ -181,6 +181,7 @@ class BddSubscriber implements EventSubscriberInterface
         $resultCode          = $event->getTestResult()->getResultCode();
         $stepText            = sprintf("%s %s", $event->getStep()->getKeyword(), $event->getStep()->getText());
         $valuesTables        = [];
+        $screenshotOnFailed  = Athena::settings()->get('bddScreenshotOnlyOnFailed')->orDefaultTo(true);
 
         // not the most pretty implementation
         if ($event->getStep()->hasArguments()) {
@@ -203,17 +204,17 @@ class BddSubscriber implements EventSubscriberInterface
             }
         }
 
-        if (($resultCode == TestResult::FAILED) AND (Athena::settings()->get('bddScreenshotOnlyOnFailed')->orDefaultTo(true) == true)){
+        if (($resultCode == TestResult::FAILED) && ($screenshotOnFailed == true)){
             $imageFileName = $this->takeScreenshot();
             $httpTransactions = $this->getHttpTransactionEvents();
 
             $this->report->finishStep($stepText, $valuesTables, $resultCode, $imageFileName, $exceptionMessage, $exceptionTrace, $exceptionType, $httpTransactions);
-        } elseif (Athena::settings()->get('bddScreenshotOnlyOnFailed')->orDefaultTo(true) == false) {
+        } elseif ($screenshotOnFailed == false) {
             $imageFileName = $this->takeScreenshot();
             $httpTransactions = $this->getHttpTransactionEvents();
 
             $this->report->finishStep($stepText, $valuesTables, $resultCode, $imageFileName, $exceptionMessage, $exceptionTrace, $exceptionType, $httpTransactions);
-        } elseif (($resultCode == TestResult::PASSED) AND (Athena::settings()->get('bddScreenshotOnlyOnFailed')->orDefaultTo(true) == true)) {
+        } elseif (($resultCode == TestResult::PASSED) && ($screenshotOnFailed == true)) {
             $imageFileName = null;
             $httpTransactions = null;
 

--- a/src/Event/Subscriber/BddSubscriber.php
+++ b/src/Event/Subscriber/BddSubscriber.php
@@ -203,10 +203,22 @@ class BddSubscriber implements EventSubscriberInterface
             }
         }
 
-        $imageFileName = $this->takeScreenshot();
-        $httpTransactions = $this->getHttpTransactionEvents();
+        if (($resultCode == TestResult::FAILED) AND (Athena::settings()->get('bddScreenshotOnlyOnFailed')->orDefaultTo(true) == 'on')){
+            $imageFileName = $this->takeScreenshot();
+            $httpTransactions = $this->getHttpTransactionEvents();
 
-        $this->report->finishStep($stepText, $valuesTables, $resultCode, $imageFileName, $exceptionMessage, $exceptionTrace, $exceptionType, $httpTransactions);
+            $this->report->finishStep($stepText, $valuesTables, $resultCode, $imageFileName, $exceptionMessage, $exceptionTrace, $exceptionType, $httpTransactions);
+        } elseif (Athena::settings()->get('bddScreenshotOnlyOnFailed')->orDefaultTo(true) == 'off') {
+            $imageFileName = $this->takeScreenshot();
+            $httpTransactions = $this->getHttpTransactionEvents();
+
+            $this->report->finishStep($stepText, $valuesTables, $resultCode, $imageFileName, $exceptionMessage, $exceptionTrace, $exceptionType, $httpTransactions);
+        } elseif (($resultCode == TestResult::PASSED) AND (Athena::settings()->get('bddScreenshotOnlyOnFailed')->orDefaultTo(true) == 'on')) {
+            $imageFileName = null;
+            $httpTransactions = null;
+
+            $this->report->finishStep($stepText, $valuesTables, $resultCode, $imageFileName, $exceptionMessage, $exceptionTrace, $exceptionType, $httpTransactions);
+        }
     }
 
     /**

--- a/src/Logger/Template/cucumber_report.twig
+++ b/src/Logger/Template/cucumber_report.twig
@@ -46,8 +46,12 @@
     "description": "",
     "type" : "scenario",
     "tags":[
-    {% for tag in test.tags %}
-        {"name": "{{ tag }}"}
+    {% for key in test.tags|keys %}
+        {% if loop.last == true %}
+            {"name": "{{ test.tags[key] }}"}
+        {% else %}
+            {"name": "{{  test.tags[key] }}"},
+        {% endif %}
     {% endfor %}
     ],
     "steps" : [
@@ -65,7 +69,7 @@
             {% endif %}
 
 
-        "status" : "{{ step.status }}"
+        "status" : "{{  }}"
 
         },
         {% if step.children is not empty %}


### PR DESCRIPTION
Added configuration "**bddScreenshotOnlyOnFailed**" to turn on and off the screenshots after steps for BDD tests. The BDD tests should now have option to add "**bddScreenshotOnlyOnFailed**" section in json config with "on" and "off" value.

Where:
on = screenshot will only take when step is failed
off = there is screenshot for every steps

@caiomoritz @pproenca kindly review this change.

Thank you.